### PR TITLE
Dynamic help command

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -23,19 +23,26 @@ client.on("ready", () => {
 });
 
 client.on("message", message => {
+
     function isValidCommand(message) {
         return (message.content.startsWith(prefix) && !message.author.bot);
     } // returns whether or not the message is a valid command
     
-    if (isValidCommand(message)) { return; } // exits if the message is not a valid command
-    const args = message.content.slice(prefix.length).split(" +");
-    const commmandName = args.shift().toLowerCase();
-
+    if (!isValidCommand(message)) { return; }
+    // exits if the message is not a valid command
+    const args = message.content.slice(prefix.length).split(/ +/);
+    const commandName = args.shift().toLowerCase();
+    
+    // const command = client.commands.get(commandName)
+	// 	|| client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));
+    // if (!command) return;
     const command = client.commands.get(commandName)
-                    || client.commands.find(cmd => cmd.aliases.includes(commandName));
-    if (!command) { return; }
+		|| client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));
 
-    if (command.args && !args.length) {
+	if (!command) return;
+
+
+    if (command.args === true && !args.length && !typeof command === "string") {
         let reply = `You didn't provide any arguments, ${message.author}.`;
         if (command.usage) {
             reply += `\nThe proper usage would be:\n${prefix}${command.name} ${command.usage}`;
@@ -58,6 +65,10 @@ client.on("message", message => {
 
     if (checkRole(message, metadata.roles.staff.name)) { return; }
     if (checkRole(message, metadata.roles.admin.name)) { return; }
+
+    if (!cooldowns.has(command.name)) {
+        cooldowns.set(command.name, new Discord.Collection());
+    }
 
     const now = Date.now(); // var with current time
     const timestamps = cooldowns.get(command.name); // var that gets the Collection for triggered command

--- a/bot.js
+++ b/bot.js
@@ -42,7 +42,7 @@ client.on("message", message => {
 	if (!command) return;
 
 
-    if (command.args === true && !args.length && !typeof command === "string") {
+    if ((command.args === true || !typeof command === "string") && !args.length) {
         let reply = `You didn't provide any arguments, ${message.author}.`;
         if (command.usage) {
             reply += `\nThe proper usage would be:\n${prefix}${command.name} ${command.usage}`;

--- a/commands/help.js
+++ b/commands/help.js
@@ -45,12 +45,27 @@ module.exports = {
             // commands with the type equal to 'filter'.
         }
 
+        function sortListsByOrder(lists) {
+            let information = [];
+            for (let i = 1; i <= 4; i++) {
+                let currentList = lists.filter(list => {
+                    return list.position === i;
+                });
+                let mapped = currentList.map(cur => `List ${cur.position}: ${cur.type} commands.`);
+                information.push(mapped[0]);
+                console.log(information);
+            };
+            return information;        
+        }
+
         function constructEmbedList(list, lists) {
             let items = list.items.map(item => item.name).join('\n');
             // Joins all of the names of the items in the list
             // with a new line between them.
             items.slice(items.length - 2, items.length);
             // Removes the final \n, so it doesn't look weird.
+            
+            // I know this is a horrible variable name, couldn't think of anything better.
 
             const embed = new Discord.MessageEmbed()
             .setColor(color || "#0000FF")
@@ -61,6 +76,7 @@ module.exports = {
                             `please type ${prefix}list <command>.\n` +
                             `In order to execute a command, please use the '${prefix}' prefix.`)
             .addField("**Commands:**", items || "empty or error.")
+            .addField("**Lists**", sortListsByOrder(lists))
             .setFooter("Odin")
             .setTimestamp();
             return embed;

--- a/commands/help.js
+++ b/commands/help.js
@@ -97,24 +97,32 @@ module.exports = {
         if (isRequestingList(args)) {
             // Constructing the lists
             let lists = [];
+
+            let completeList = {
+                items: commands,
+                type: "all",
+                position: 1
+            }
+            lists.push(completeList);
+
             let supportList = {
                 items: filterList(commands, "support"),
                 type: "support",
-                position: 1
+                position: 2
             };
             lists.push(supportList);
 
             let miscList = {
                 items: filterList(commands, "misc"),
                 type: "miscellaneous",
-                position: 2
+                position: 3
             };
             lists.push(miscList);
 
             let modList = {
                 items: filterList(commands, "moderation"),
                 type: "moderation",
-                position: 3
+                position: 4
             };
             lists.push(modList);
             // This sorts through all of the commands, and sorts them
@@ -122,16 +130,18 @@ module.exports = {
             message.delete();
             switch (parseInt(args[0])) {
                 case 1:
+                    message.channel.send(constructEmbedList(completeList, lists));
+                case 2:
                     message.channel.send(constructEmbedList(supportList, lists));
                     break;
-                case 2:
+                case 3:
                     message.channel.send(constructEmbedList(miscList, lists));
                     break;
-                case 3:
+                case 4:
                     message.channel.send(constructEmbedList(modList, lists));
                     break;
                 default:
-                    message.channel.send(constructEmbedList(supportList, lists));
+                    message.channel.send(constructEmbedList(completeList, lists));
                     break;
             }; // Sends the desired list
         }

--- a/commands/help.js
+++ b/commands/help.js
@@ -53,7 +53,6 @@ module.exports = {
                 });
                 let mapped = currentList.map(cur => `List ${cur.position}: ${cur.type} commands.`);
                 information.push(mapped[0]);
-                console.log(information);
             };
             return information;        
         }

--- a/commands/help.js
+++ b/commands/help.js
@@ -13,6 +13,10 @@ module.exports = {
     execute(message, args) {
         const { commands } = message.client;
 
+        function capitalizeFirstLetter(string) {
+            return string.charAt(0).toUpperCase() + string.slice(1);
+        }
+
         function isRequestingList(args) {
             if (!args.length) {
                 return true;
@@ -24,7 +28,8 @@ module.exports = {
         }
 
         function isRequestingSpecification(args, commands) {
-            if (commands.contains(args[0])) { // I need this return return T/F if the array 'commands' has the value of 'args[0]'.
+            if (commands.some(command => { return command.name === args[0] }) ||
+                commands.find(cmd => cmd.aliases && cmd.aliases.includes(args[0]))) { 
                 return true;
             } else {
                 return false;
@@ -32,7 +37,7 @@ module.exports = {
         }
 
         function filterList(commands, filter) {
-            var list = commands.filter(command => {
+            let list = commands.filter(command => {
                 return command.type === filter;
             });
             return list;
@@ -60,6 +65,33 @@ module.exports = {
             .setTimestamp();
             return embed;
 
+        }
+
+        function constructEmbedSpecification(args, commands) {
+            let command = commands.get(args[0]) ||
+                        commands.find(cmd => cmd.aliases && cmd.aliases.includes(args[0]));
+            
+            let details = [];
+
+            details.push(`**Command name:** ${command.name}`);
+            if (command.aliases) { details.push(`**Command aliases:** ${command.aliases.join(', ')}`); };
+            if (command.description) { details.push(`**Command description:** ${command.description}`); };
+            if (command.usage) { details.push(`**Command usage:** ${prefix}${command.name} ${command.usage}`); };
+            details.push(`**Command cooldown:** ${command.cooldown || 3} seconds.`);
+
+            let information = details.join('\n');
+            information.slice(information.length - 2, information.length);
+            
+            const embed = new Discord.MessageEmbed()
+            .setColor(color || "#0000FF")
+            .setTitle(`${capitalizeFirstLetter(command.name)} Command Details:`)
+            .setAuthor("Odin")
+            .setDescription(`Here are some details about the ${command.name} command.`)
+            .addField("Information:", information)
+            .setFooter("Odin")
+            .setTimestamp();
+
+            return embed;
         }
 
         if (isRequestingList(args)) {
@@ -105,7 +137,7 @@ module.exports = {
         }
 
         if (isRequestingSpecification(args, commands)) {
-            console.log("yoooooo dude")
+            message.channel.send(constructEmbedSpecification(args, commands));
         }
     }
 }

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,0 +1,111 @@
+const Discord = require('discord.js');
+const { prefix, color } = require('../config.json')
+
+module.exports = {
+    name: 'help',
+    description: 'Lists all availible commands.\nIf a command is specified, additional details will be listed.',
+    aliases: ['list', 'commands'],
+    type: "support",
+    usage: "<command or 'desc'>",
+    args: "optional",
+    cooldown: 3,
+    permissions: false,
+    execute(message, args) {
+        const { commands } = message.client;
+
+        function isRequestingList(args) {
+            if (!args.length) {
+                return true;
+            } else if (Number.isInteger(parseInt(args[0]))) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        function isRequestingSpecification(args, commands) {
+            if (commands.contains(args[0])) { // I need this return return T/F if the array 'commands' has the value of 'args[0]'.
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        function filterList(commands, filter) {
+            var list = commands.filter(command => {
+                return command.type === filter;
+            });
+            return list;
+            // This will sort through the commands and return all
+            // commands with the type equal to 'filter'.
+        }
+
+        function constructEmbedList(list, lists) {
+            let items = list.items.map(item => item.name).join('\n');
+            // Joins all of the names of the items in the list
+            // with a new line between them.
+            items.slice(items.length - 2, items.length);
+            // Removes the final \n, so it doesn't look weird.
+
+            const embed = new Discord.MessageEmbed()
+            .setColor(color || "#0000FF")
+            .setTitle(`Command List (${list.position}/${lists.length})`)
+            .setAuthor("Odin")
+            .setDescription(`The following is a list of ${list.type} commands.\n` +
+                            `To receive more information about a specific command, ` +
+                            `please type ${prefix}list <command>.\n` +
+                            `In order to execute a command, please use the '${prefix}' prefix.`)
+            .addField("**Commands:**", items || "empty or error.")
+            .setFooter("Odin")
+            .setTimestamp();
+            return embed;
+
+        }
+
+        if (isRequestingList(args)) {
+            // Constructing the lists
+            let lists = [];
+            let supportList = {
+                items: filterList(commands, "support"),
+                type: "support",
+                position: 1
+            };
+            lists.push(supportList);
+
+            let miscList = {
+                items: filterList(commands, "misc"),
+                type: "miscellaneous",
+                position: 2
+            };
+            lists.push(miscList);
+
+            let modList = {
+                items: filterList(commands, "moderation"),
+                type: "moderation",
+                position: 3
+            };
+            lists.push(modList);
+            // This sorts through all of the commands, and sorts them
+            // into three lists, depending on their "type" attribute.
+            message.delete();
+            switch (parseInt(args[0])) {
+                case 1:
+                    message.channel.send(constructEmbedList(supportList, lists));
+                    break;
+                case 2:
+                    message.channel.send(constructEmbedList(miscList, lists));
+                    break;
+                case 3:
+                    message.channel.send(constructEmbedList(modList, lists));
+                    break;
+                default:
+                    message.channel.send(constructEmbedList(supportList, lists));
+                    break;
+            }; // Sends the desired list
+        }
+
+        if (isRequestingSpecification(args, commands)) {
+            console.log("yoooooo dude")
+        }
+    }
+}


### PR DESCRIPTION
This adds a functional dynamic help command.
The help command lists the commands by type, and also lists a list of availible lists at the bottom. There are currently four lists, and three types:
List 1) all, lists all commands
List 2) support, lists support commands
List 3) miscellaneous, lists misc commands
List 4) moderation, lists moderation commands.
The desired list can be specified by a number following the command (e.g !list 3 for misc list), and if no number is specified it will default to the 'all' list.
The command can also provide additional information about commands, by typing !list [command].