### PR TITLE
Help patch

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -33,6 +33,8 @@ module.exports = {
                 commands.find(cmd => cmd.aliases && cmd.aliases.includes(args[0]))) { 
                 return true;
             } else {
+                let response = new Discord.MessageEmbed().setDescription('That is not a valid command. Please specifiy a valid command.');
+                message.channel.send(response);
                 return false;
             }
         }
@@ -160,9 +162,7 @@ module.exports = {
                     message.channel.send(constructEmbedList(completeList, lists));
                     break;
             }; // Sends the desired list
-        }
-
-        if (isRequestingSpecification(args, commands)) {
+        } else if (isRequestingSpecification(args, commands)) {
             message.delete();
             message.channel.send(constructEmbedSpecification(args, commands));
         }

--- a/commands/help.js
+++ b/commands/help.js
@@ -92,9 +92,10 @@ module.exports = {
             let details = [];
 
             details.push(`**Command name:** ${command.name}`);
-            if (command.aliases) { details.push(`**Command aliases:** ${command.aliases.join(', ')}`); };
-            if (command.description) { details.push(`**Command description:** ${command.description}`); };
-            if (command.usage) { details.push(`**Command usage:** ${prefix}${command.name} ${command.usage}`); };
+            details.push(`**Command aliases:** ${command.aliases.join(', ')}`);
+            details.push(`**Command description:** ${command.description}`);
+            details.push(`**Command usage:** ${prefix}${command.name} ${command.usage}`);
+            details.push(`**Command permissions:** ${command.permissions}`);
             details.push(`**Command cooldown:** ${command.cooldown || 3} seconds.`);
 
             let information = details.join('\n');


### PR DESCRIPTION
Closes #5 
Closes #10

What was changed in the merge:
-
- help.js -> Improved command specification:
  - If a user attempts to request an invalid command, the bot will now alert them, and instruct them to specfiy a valid command.
  - When requesting specification for a command, the commands `permission` property will now be displayed.
  - Removed the conditionals for the command specification, because all fields should be present.